### PR TITLE
unittest and fix between-date expression

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -10,10 +10,10 @@
     <RadMajor>0</RadMajor>
     <RadMinor>1</RadMinor>
     <RadPatch>1</RadPatch>
-    <RadBuild>77</RadBuild>
-    <PackageVersionShort>0.1.1</PackageVersionShort>
-    <PackageVersionFull>0.1.1+77.191103103154.release.9fb9ff5</PackageVersionFull>
-    <GitCommit>9fb9ff5</GitCommit>
-    <GitBranch>release</GitBranch>
+    <RadBuild>88</RadBuild>
+    <PackageVersionShort>0.1.1-dev.88.200525223639</PackageVersionShort>
+    <PackageVersionFull>0.1.1-dev.88.200525223639+29.master.3b373b1-dirty</PackageVersionFull>
+    <GitCommit>3b373b1-dirty</GitCommit>
+    <GitBranch>master</GitBranch>
   </PropertyGroup>
 </Project>

--- a/net.adamec.lib.common.dmn.engine.test/complex/InputDateRangeTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test/complex/InputDateRangeTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using net.adamec.lib.common.dmn.engine.engine.runtime;
+using net.adamec.lib.common.dmn.engine.parser;
+
+namespace net.adamec.lib.common.dmn.engine.test.complex
+{
+    [TestClass]
+    [TestCategory("Complex tests")]
+    public class InputDateRangeTests
+    {
+        private DmnExecutionContext ctx;
+        [TestInitialize]
+        public void InitCtx()
+        {
+            var dir = AppDomain.CurrentDomain.BaseDirectory;
+            var file = Path.Combine(dir, "dmn/date_between_expression.dmn");
+            ctx = DmnExecutionContextFactory.CreateExecutionContext(DmnParser.Parse(file));
+        }
+
+        [TestCleanup]
+        public void ResetCtx()
+        {
+            ctx.Reset();
+        }
+
+        [TestMethod]
+        public void DateBetweenInputTest()
+        {
+            ctx.WithInputParameter("Date", new DateTime(2010,1,1));
+
+            var result = ctx.ExecuteDecision("date_between_decision");
+
+            
+        }
+    }
+}

--- a/net.adamec.lib.common.dmn.engine.test/dmn/date_between_expression.dmn
+++ b/net.adamec.lib.common.dmn.engine.test/dmn/date_between_expression.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="Definitions_0szzjs7" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.2">
+  <decision id="Decision_0td19xn" name="date_between_decision">
+    <extensionElements>
+      <biodi:bounds x="160" y="180" width="180" height="80" />
+      <biodi:edge source="InputData_02piyxw">
+        <biodi:waypoints x="518" y="122" />
+        <biodi:waypoints x="340" y="180" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredInput href="#InputData_02piyxw" />
+    </informationRequirement>
+    <decisionTable id="decisionTable_1">
+      <input id="input_1" label="Date">
+        <inputExpression id="inputExpression_1" typeRef="date">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="output_1" typeRef="boolean" />
+      <rule id="DecisionRule_0nmrs1v">
+        <inputEntry id="UnaryTests_0jxrxsp">
+          <text>[date and time("2000-05-25T00:00:00")..date and time("2030-05-25T00:00:00")]</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0uuynig">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <inputData id="InputData_02piyxw" name="Date">
+    <extensionElements>
+      <biodi:bounds x="518" y="78" width="125" height="45" />
+    </extensionElements>
+  </inputData>
+</definitions>

--- a/net.adamec.lib.common.dmn.engine.test/net.adamec.lib.common.dmn.engine.test.csproj
+++ b/net.adamec.lib.common.dmn.engine.test/net.adamec.lib.common.dmn.engine.test.csproj
@@ -32,6 +32,9 @@
     <None Update="dmn\datatypes_err.dmn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="dmn\date_between_expression.dmn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="dmn\dynamictypes.dmn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
I ran an issue with a date column with between-date expression when providing null as input value: The expression failed to parse as no type information was available (was not extracted during input variable definition generation). The code suggested values to be of type object when input value is null which leads equalOrGreater expressions (object <= dateTime) to fail.

The fix extracts types for input variables from the corresponding decision table and saves it together with the variable (whose type was always null). Having type information together with the variable will not let the above mentioned expression parsing fail.