### PR TITLE
Added in the ability to return back the positively matched rules for e…

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -10,10 +10,10 @@
     <RadMajor>0</RadMajor>
     <RadMinor>1</RadMinor>
     <RadPatch>2</RadPatch>
-    <RadBuild>109</RadBuild>
-    <PackageVersionShort>0.1.2</PackageVersionShort>
-    <PackageVersionFull>0.1.2+109.200718213753.release.6f31eef</PackageVersionFull>
-    <GitCommit>6f31eef</GitCommit>
-    <GitBranch>release</GitBranch>
+    <RadBuild>177</RadBuild>
+    <PackageVersionShort>0.1.2-dev.177.211011105320</PackageVersionShort>
+    <PackageVersionFull>0.1.2-dev.177.211011105320+34.master.895f577-dirty</PackageVersionFull>
+    <GitCommit>895f577-dirty</GitCommit>
+    <GitBranch>master</GitBranch>
   </PropertyGroup>
 </Project>

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/AllowedValuesTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/AllowedValuesTests.cs
@@ -52,6 +52,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterThan(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/AllowedValuesTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/AllowedValuesTests13.cs
@@ -52,6 +52,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/ComplexInputsTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/ComplexInputsTests.cs
@@ -42,7 +42,12 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
-            
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterThan(0);
+            }
+
             var val = direct == "over" ? "dyna.Direct==over" : name + isOk + direct;
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/ComplexInputsTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/ComplexInputsTests13.cs
@@ -42,7 +42,12 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
-            
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
+
             var val = direct == "over" ? "dyna.Direct==over" : name + isOk + direct;
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/EndToEndTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/EndToEndTests.cs
@@ -37,6 +37,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -55,6 +60,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -78,6 +88,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(2);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var o1 = result.SingleResult[0];
             o1.Should().NotBeNull();
@@ -110,6 +125,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -135,6 +155,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/EndToEndTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/EndToEndTests13.cs
@@ -37,6 +37,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -55,6 +60,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -78,6 +88,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(2);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var o1 = result.SingleResult[0];
             o1.Should().NotBeNull();
@@ -110,6 +125,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().Be(0);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();
@@ -135,6 +155,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyMultiOutTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyMultiOutTests.cs
@@ -38,6 +38,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (!hasHit)
             {
@@ -111,6 +116,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (!hasHit)
             {
@@ -191,6 +201,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (!hasHit)
             {
@@ -306,6 +321,12 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
+
 
             if (!hasHit)
             {
@@ -394,6 +415,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (!hasHit)
             {
@@ -496,6 +522,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (!hasHit)
             {

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyMultiOutTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyMultiOutTests13.cs
@@ -52,6 +52,13 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
+
+
             var outCount = 0;
             if (o1 != null) outCount++;
             if (o2 != null) outCount++;
@@ -125,6 +132,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             var outCount = 0;
             if (o1 != null) outCount++;
             if (o2 != null) outCount++;
@@ -202,6 +214,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(1);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
@@ -320,6 +337,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             var outCount = 2;
             var o1Index = 0;
             var o2Index = 1;
@@ -406,6 +428,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             var hitsCount = o1.Length;
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount == 1)
             {
@@ -508,6 +535,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             var hitsCount = o1.Length;
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount == 1)
             {

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyTest.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyTest.cs
@@ -68,6 +68,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(outVariableCount);
             }
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (outVariableCount <= 0) return;
 
@@ -108,6 +113,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -172,6 +182,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -246,6 +261,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
                 result.IsSingleResult.Should().Be(true);
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(outVariableCount);
+            }
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
             }
 
             if (outVariableCount <= 0) return;
@@ -323,6 +343,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(outVariableCount[0]);
             }
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             for (var i = 0; i < hitsCount; i++)
             {
@@ -373,6 +398,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -471,6 +501,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -554,6 +589,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -619,6 +659,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -669,6 +714,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -734,6 +784,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {
@@ -814,6 +869,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -879,6 +939,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -944,6 +1009,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -1010,6 +1080,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
 
             result.Should().NotBeNull();
             result.Results.Should().NotBeNull();
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (hitsCount <= 0)
             {

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyTest13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/HitPolicyTest13.cs
@@ -62,6 +62,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             if (hitsCount == 1)
             {
                 result.IsSingleResult.Should().Be(true);
@@ -119,6 +124,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             if (hitsCount == 1)
             {
                 result.IsSingleResult.Should().Be(true);
@@ -189,6 +199,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(outVariableCount);
             }
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             if (outVariableCount <= 0) return;
 
@@ -246,6 +261,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
                 result.IsSingleResult.Should().Be(true);
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(outVariableCount);
+            }
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
             }
 
             if (outVariableCount <= 0) return;
@@ -317,6 +337,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             if (hitsCount == 1)
             {
                 result.IsSingleResult.Should().Be(true);
@@ -384,6 +409,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             if (hitsCount == 1)
             {
                 result.IsSingleResult.Should().Be(true);
@@ -482,6 +512,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
 
             result.Results.Should().HaveCount(hitsCount);
             result.HasResult.Should().Be(true);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
             if (hitsCount == 1)
             {
                 result.IsSingleResult.Should().Be(true);
@@ -554,6 +589,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -619,6 +659,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -684,6 +729,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -749,6 +799,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -814,6 +869,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -879,6 +939,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -944,6 +1009,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];
@@ -1025,6 +1095,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             result.Results[0].Variables.Should().HaveCount(1);
             var output = result.Results[0].Variables[0];

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/ParallelTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/ParallelTests.cs
@@ -60,6 +60,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
                 result.IsSingleResult.Should().Be(true);
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(3);
+                foreach (var r in result.Results)
+                {
+                    r.MatchedRules.Should().NotBeNull();
+                    r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+                }
 
                 var outNumInOut = result.SingleResult[2];
                 outNumInOut.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/ParallelTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/ParallelTests13.cs
@@ -60,6 +60,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
                 result.IsSingleResult.Should().Be(true);
                 result.SingleResult.Should().NotBeNull();
                 result.SingleResult.Should().HaveCount(3);
+                foreach (var r in result.Results)
+                {
+                    r.MatchedRules.Should().NotBeNull();
+                    r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+                }
 
                 var outNumInOut = result.SingleResult[2];
                 outNumInOut.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/SfeelExpressionsTests.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/SfeelExpressionsTests.cs
@@ -208,6 +208,11 @@ namespace net.adamec.lib.common.dmn.engine.test.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine.test.net/complex/SfeelExpressionsTests13.cs
+++ b/net.adamec.lib.common.dmn.engine.test.net/complex/SfeelExpressionsTests13.cs
@@ -208,6 +208,11 @@ namespace net.adamec.lib.common.dmn.engine.test.net.complex
             result.IsSingleResult.Should().Be(true);
             result.SingleResult.Should().NotBeNull();
             result.SingleResult.Should().HaveCount(1);
+            foreach (var r in result.Results)
+            {
+                r.MatchedRules.Should().NotBeNull();
+                r.MatchedRules.Count.Should().BeGreaterOrEqualTo(1);
+            }
 
             var output = result.SingleResult[0];
             output.Should().NotBeNull();

--- a/net.adamec.lib.common.dmn.engine/engine/decisions/DmnDecisionSingleResult.cs
+++ b/net.adamec.lib.common.dmn.engine/engine/decisions/DmnDecisionSingleResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using net.adamec.lib.common.dmn.engine.engine.decisions.table.definition;
 using net.adamec.lib.common.dmn.engine.engine.runtime;
 
 namespace net.adamec.lib.common.dmn.engine.engine.decisions
@@ -17,7 +18,10 @@ namespace net.adamec.lib.common.dmn.engine.engine.decisions
         /// List of result variables
         /// </summary>
         public IReadOnlyList<DmnExecutionVariable> Variables => variables;
-
+        /// <summary>
+        /// Capture of the rule that matched this decision
+        /// </summary>
+        public List<DmnDecisionTableRule> MatchedRules { get; internal set; } = new List<DmnDecisionTableRule>();
         /// <summary>
         /// Add result variable into the decision result
         /// </summary>

--- a/net.adamec.lib.common.dmn.engine/engine/decisions/table/DmnDecisionTable.cs
+++ b/net.adamec.lib.common.dmn.engine/engine/decisions/table/DmnDecisionTable.cs
@@ -180,6 +180,7 @@ namespace net.adamec.lib.common.dmn.engine.engine.decisions.table
                             //no value for sum, min, max
                             outputVariable.Value = null;
                             retVal += new DmnDecisionSingleResult() + outputVariable.Clone();
+                            retVal.Results[0].MatchedRules.AddRange(positiveRules);
                             return retVal;
                         }
                         // ReSharper disable once SwitchStatementMissingSomeCases
@@ -200,6 +201,7 @@ namespace net.adamec.lib.common.dmn.engine.engine.decisions.table
                         }
 
                         retVal += new DmnDecisionSingleResult() + outputVariable.Clone();
+                        retVal.Results[0].MatchedRules.AddRange(positiveRules);
                         return retVal;
 
                     }
@@ -229,6 +231,7 @@ namespace net.adamec.lib.common.dmn.engine.engine.decisions.table
             foreach (var multiMatchOutputRule in positiveMatchOutputRules)
             {
                 var singleResult = new DmnDecisionSingleResult();
+                singleResult.MatchedRules.Add(multiMatchOutputRule);
                 foreach (var ruleOutput in multiMatchOutputRule.Outputs)
                 {
                     var resultOutput = results.GetResult(multiMatchOutputRule, ruleOutput);

--- a/net.adamec.lib.common.dmn.engine/engine/runtime/DmnExecutionContext.cs
+++ b/net.adamec.lib.common.dmn.engine/engine/runtime/DmnExecutionContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using DynamicExpresso;
@@ -23,7 +24,7 @@ namespace net.adamec.lib.common.dmn.engine.engine.runtime
         /// <summary>
         /// Parsed (pre-processed) expressions cache
         /// </summary>
-        private static readonly Dictionary<(string, Type), Lambda> ParsedExpressionsCache = new Dictionary<(string, Type), Lambda>();
+        private static readonly ConcurrentDictionary<(string, Type), Lambda> ParsedExpressionsCache = new ConcurrentDictionary<(string, Type), Lambda>();
 
         /// <summary>
         /// DMN Model definition


### PR DESCRIPTION
…ach decision result.

We needed to do this for audit reasons, so we can show a user which rules matched after decisions had been made.