### PR TITLE
allowing international letters like æøå

### DIFF
--- a/net.adamec.lib.common.dmn.engine/engine/definition/DmnVariableDefinition.cs
+++ b/net.adamec.lib.common.dmn.engine/engine/definition/DmnVariableDefinition.cs
@@ -140,10 +140,10 @@ namespace net.adamec.lib.common.dmn.engine.engine.definition
             if (string.IsNullOrWhiteSpace(retVal))
                 throw new ArgumentException($"Variable name is null or empty",nameof(name));
 
-            if (retVal.Any(c => !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_')))
+            if (retVal.Any(c => char.IsLetter(c) || char.IsDigit(c)  || c == '_')))
                 throw new ArgumentException($"Variable name '{name}' contains invalid character", nameof(name));
 
-            if (!(retVal[0] >= 'a' && retVal[0] <= 'z' || retVal[0] >= 'A' && retVal[0] <= 'Z'))
+            if (!char.IsLetter(retVal[0])
                 throw new ArgumentException($"Variable name '{nameof(name)}' must start with letter", nameof(name));
 
             return retVal;

--- a/net.adamec.lib.common.dmn.engine/engine/definition/DmnVariableDefinition.cs
+++ b/net.adamec.lib.common.dmn.engine/engine/definition/DmnVariableDefinition.cs
@@ -140,10 +140,10 @@ namespace net.adamec.lib.common.dmn.engine.engine.definition
             if (string.IsNullOrWhiteSpace(retVal))
                 throw new ArgumentException($"Variable name is null or empty",nameof(name));
 
-            if (retVal.Any(c => char.IsLetter(c) || char.IsDigit(c)  || c == '_')))
+            if (retVal.Any(c => !(char.IsLetter(c) || char.IsDigit(c)  || c == '_')))
                 throw new ArgumentException($"Variable name '{name}' contains invalid character", nameof(name));
 
-            if (!char.IsLetter(retVal[0])
+            if (!char.IsLetter(retVal[0]))
                 throw new ArgumentException($"Variable name '{nameof(name)}' must start with letter", nameof(name));
 
             return retVal;


### PR DESCRIPTION
Ref issue: https://github.com/adamecr/Common.DMN.Engine/issues/11#issue-1095391942
In the latest version of the library the following code has been introduced to validate input names:
https://github.com/adamecr/Common.DMN.Engine/blob/524e55ee19583166c83b0d9db3002bfc808923ec/net.adamec.lib.common.dmn.engine/engine/definition/DmnVariableDefinition.cs#L136

For out part this brakes because of using Norwegian letters like æ, ø, å, within the DMN files, and also as input params to the library.

A better solution would probably be to use the .net function: 
```C#
public static string NormalizeVariableName(string name)
{
    var retVal = name?.Trim().Replace(' ', '_');

    if (string.IsNullOrWhiteSpace(retVal))
        throw new ArgumentException($"Variable name is null or empty",nameof(name));

    if (retVal.Any(c => char.IsLetter(c) || char.IsDigit(c)  || c == '_')))
        throw new ArgumentException($"Variable name '{name}' contains invalid character", nameof(name));

    if (!char.IsLetter(retVal[0])
        throw new ArgumentException($"Variable name '{nameof(name)}' must start with letter", nameof(name));

    return retVal;
}
```